### PR TITLE
Fix instructions to download generate_report.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,30 @@
 # License Report
 
-License Report is an open-source compliance tool that generates a
-summary report of package license information for Alpine, Debian and
-Python packages. The tool is intended to be run inside the build stage
-of Docker images, where the generated report can be embedded.
-
-## File Layout
-
---- license-report
-    |--- generate_report.sh (Creates a report)
-    |--- README.md
-    |--- LICENSE.md
-    |--- tests
-    |    |--- tests.sh (Automated tests for generate_report.sh)
-    |    |--- Makefile (Simplifies usage of tests.sh)
+An open-source compliance tool that generates a summary of OSS license information for packages in a Docker image. The project currently supports Alpine, Debian and Python packages, and their information is retrieved using terminal commands and their respective package managers.
 
 ## Getting Started
 
 ### Requirements
 
-generate_report.sh is a shell script, so nothing extra should be
-needed to execute the file.
+generate_report.sh is a shell script, so nothing extra should be needed to execute the file.
 
-However, licensecheck is an optional dependency for sourcing Debian
-packages:
+However, licensecheck is an optional dependency for sourcing Debian packages:
 
     apt install licensecheck
 
-Update the apk package index before generating a report if
-applicable. The following warning will be raised otherwise:
+Refresh the apk package index using "apk update" before generating a report. The following warning will otherwise be raised for each package:
 
     apk WARNING: Ignoring APKINDEX: No such file or directory
 
 ### Installing
 
-Download the project from Github:
+Download the entire project from Github:
 
     git clone https://github.com/WindRiver-OpenSourceLabs/license-report
 
-Alternatively, pull only the generate_report.sh script:
+Download the generate_report.sh script only (Requires curl):
 
-    curl -L https://github.com/downloads/WindRiver-OpenSourceLabs/license-report/generate_report.sh
+    curl --silent --remote-name https://raw.githubusercontent.com/WindRiver-OpenSourceLabs/license-report/master/generate_report.sh
 
 ## Usage
 
@@ -64,13 +48,9 @@ EOF
 
 ### Output Description
 
-Reports created by generate_report.sh will be printed to the
-console. This is so the user can control what is done with the output,
-as demonstrated in Applications.
+Reports created by generate_report.sh will be printed to the console. This is so the user can control what is done with the output, as demonstrated in Applications.
 
-A package entry follows this general format:
-
-    ----------------------------------------------------------------------------------------
+An entry for a package follows this format:
 
     Package Name: <Name>
     Package Type: <Type>
@@ -78,15 +58,9 @@ A package entry follows this general format:
     Source URL: <URL>
     License: <License Codes>
 
-If the version, source url or license code of a package cannot be
-found, then the field "N/A" will be provided in its place. A package
-entry is required to have at least one of those fields so that the
-information it provides will be of value. The binary for Debian
-package copyrights will be listed if the license code cannot be found
-using licensecheck (Hence the optional dependency on the package).
+If the version, source url or license code of a package cannot be found, then the field "N/A" will be provided in its place. A package entry is required to have at least one of those fields so that the information it provides will be of value. The binary for Debian package copyrights will be listed if the license code cannot be found using licensecheck.
 
-Example:
-    -----------------------------------------------------------------------------------------
+Sample entry:
 
     Package Name: amd64-microcode
     Package Type: Debian
@@ -159,31 +133,28 @@ Redirecting the output of generate_report.sh to a physical file:
 
     sh generate_report.sh > report # Output would be contained inside "report"
 
-    sh generate_report.sh -a report > appended # Entries for additional packages
-    would be contained inside "appended"
-
 Adding appended information to an existing report:
 
-    sh generate_report.sh -a report >> report
+    sh generate_report.sh --appended report >> report
 
-Creating and appending a report throughout a Dockerfile's build stages:
+Embedding a report into an image from a Dockerfile:
 
-    RUN mkdir /<report-directory> &&
-        cd /<report-directory> && \
-        curl -L https://github.com/downloads/WindRiver-OpenSourceLabs/license-report/generate_report.sh && \
-        sh generate_report > <report> && \
-        rm /<report-directory>/generate_report.sh # Skip if carrying the report through another build stage
+    RUN mkdir /license-report && \
+        cd /license-report && \
+        curl --silent --remote-name https://raw.githubusercontent.com/WindRiver-OpenSourceLabs/license-report/master/generate_report.sh && \
+        sh generate_report.sh > report && \
+        rm /license-report/generate_report.sh # Skip if carrying the report through another build stage
 
-Carrying the report into another build stage:
+Carrying the report from the initial build stage and appending to it:
 
-    COPY --from=<Previous stage> /<report-directory> /<report-directory>
+    COPY --from=0 /license-report /license-report
 
-    RUN cd /<report-directory> && \
-        sh generate_report -a <report> >> <report>
+    RUN cd /license-report && \
+        sh generate_report --appended report >> report
 
 ## Testing
 
-See tests/README.md#1
+See [here](tests/README.md) for the tests.sh README.md file.
 
 ## TODO
 
@@ -192,9 +163,7 @@ See tests/README.md#1
 
 ## Contributing
 
-Contributions submitted must be signed off under the terms of the
-Linux Foundation Developer's Certificate of Origin version 1.1. Please
-refer to: https://developercertificate.org
+Contributions submitted must be signed off under the terms of the Linux Foundation Developer's Certificate of Origin version 1.1. Please refer to: https://developercertificate.org
 
 To submit a patch:
 
@@ -203,5 +172,4 @@ To submit a patch:
 
 ## License
 
-This project is licensed under the MIT License - see the LICENSE.md#1
-file for more details.
+This project is licensed under the MIT License - the full license can be found [here](LICENSE.md).


### PR DESCRIPTION
The location originally provided to download the generate_report.sh
script was incorrect, and the curl command failed as a result. Various
section of the README.md file were also reformatted to fix syntax
errors and make the information clearer to read.

Signed-off-by: Adnan Soudki <adnan.soudki@windriver.com>